### PR TITLE
Make flags optional in adaptation field and if not present, encode as…

### DIFF
--- a/src/main/scala/scodec/protocols/mpeg/transport/AdaptationField.scala
+++ b/src/main/scala/scodec/protocols/mpeg/transport/AdaptationField.scala
@@ -5,12 +5,14 @@ import scodec.Codec
 import scodec.bits.BitVector
 import scodec.codecs._
 
+import shapeless.{ ::, HNil }
+
 /**
  * Partial modelling of the adaptation field.
  * The field extension, if present, is ignored upon decoding.
  */
 case class AdaptationField(
-  flags: AdaptationFieldFlags,
+  flags: Option[AdaptationFieldFlags],
   pcr: Option[BitVector],
   opcr: Option[BitVector],
   spliceCountdown: Option[Int],
@@ -21,12 +23,32 @@ object AdaptationField {
   private val transportPrivateData: Codec[BitVector] =
     variableSizeBits(uint8, bits)
 
-  implicit val codec: Codec[AdaptationField] = "adaptation_field" | {
-    variableSizeBytes(uint8,
-      ("adaptation_flags"       | Codec[AdaptationFieldFlags]                ) >>:~ { flags =>
-      ("pcr"                    | conditional(flags.pcrFlag, bits(48))       ) ::
-      ("opcr"                   | conditional(flags.opcrFlag, bits(48))      ) ::
-      ("splice_countdown"       | conditional(flags.splicingPointFlag, int8) ) ::
-      ("transport_private_data" | conditional(flags.transportPrivateDataFlag, transportPrivateData))
-    })}.as[AdaptationField]
+  implicit val codec: Codec[AdaptationField] = {
+    val fields = {
+      "adaptation_field" | {
+        ("field_size"               | uint8                                                  ) >>:~ { fieldSize =>
+        variableSizeBytes(provide(fieldSize),
+          ("adaptation_flags"       | conditional(fieldSize > 0, Codec[AdaptationFieldFlags])) >>:~ { flags =>
+          ("pcr"                    | conditional(flags.exists(_.pcrFlag), bits(48))         ) ::
+          ("opcr"                   | conditional(flags.exists(_.opcrFlag), bits(48))        ) ::
+          ("splice_countdown"       | conditional(flags.exists(_.splicingPointFlag), int8)   ) ::
+          ("transport_private_data" | conditional(flags.exists(_.transportPrivateDataFlag), transportPrivateData))
+        })}
+      }
+    }
+    def calcFieldSize(
+      flags: Option[AdaptationFieldFlags],
+      pcr: Option[BitVector],
+      opcr: Option[BitVector],
+      scd: Option[Int],
+      tpd: Option[BitVector]
+    ): Int = flags.fold(0) { _ =>
+      pcr.fold(0) { _.bytes.size.toInt } + opcr.fold(0) { _.bytes.size.toInt } + scd.fold(0) { _ => 1 } + tpd.fold(0) { _.bytes.size.toInt }
+    }
+    fields.xmapc {
+      case fieldSize :: flags :: pcr :: opcr :: scd :: tpd :: HNil => flags :: pcr :: opcr :: scd :: tpd :: HNil
+    } {
+      case flags :: pcr :: opcr :: scd :: tpd :: HNil => calcFieldSize(flags, pcr, opcr, scd, tpd) :: flags :: pcr :: opcr :: scd :: tpd :: HNil
+    }.as[AdaptationField]
+  }
 }

--- a/src/main/scala/scodec/protocols/mpeg/transport/Packet.scala
+++ b/src/main/scala/scodec/protocols/mpeg/transport/Packet.scala
@@ -99,10 +99,10 @@ object Packet {
 
   implicit def codec(implicit adaptationField: Codec[AdaptationField]): Codec[Packet] =
     "packet" | fixedSizeBytes(188,
-      ("header"           | Codec[TransportStreamHeader]                              ) >>:~ { hdr =>
-      ("adaptation_field" | conditional(hdr.adaptationFieldIncluded, adaptationField) ) ::
-      ("adaptation_field" | conditional(hdr.payloadUnitStartIndicator, uint8)         ) ::
-      ("payload"          | conditional(hdr.payloadIncluded, bits)                    )
+      ("header"            | Codec[TransportStreamHeader]                              ) >>:~ { hdr =>
+      ("adaptation_field"  | conditional(hdr.adaptationFieldIncluded, adaptationField) ) ::
+      ("payload_start_ind" | conditional(hdr.payloadUnitStartIndicator, uint8)         ) ::
+      ("payload"           | conditional(hdr.payloadIncluded, bits)                    )
     }).as[Packet]
 
   def validateContinuity[F[_]]: Pipe[F, Packet, Either[PidStamped[DemultiplexerError.Discontinuity], Packet]] = {


### PR DESCRIPTION
… zero length.

I know this will need to go into a series/1.1.x branch before merge given the change to AdaptationField - not sure if there's a better way to encode this but it does work.